### PR TITLE
Fix SideMenu scroll issue

### DIFF
--- a/components/SideMenuContent.tsx
+++ b/components/SideMenuContent.tsx
@@ -53,7 +53,9 @@ const SideMenuContent: React.FC<SideMenuContentProps> = ({
   };
 
   return (
-    <>
+    <div style={{
+      paddingBottom: 80 // Match BottomActionMenu height
+    }}>
       {activeTab === 'paint' && (
         <>
           <GridSizeControls
@@ -102,7 +104,7 @@ const SideMenuContent: React.FC<SideMenuContentProps> = ({
           />
         </div>
       )}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
Adding padding at the bottom of the SideMenu to allow more scroll space on mobile/smaller screens, minimal touch to avoid stepping on any toes with ongoing development

https://github.com/stevieraykatz/HexPad/issues/2